### PR TITLE
[Repo Assist] eng: pin actions/checkout to SHA and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install gh-aw extension
         uses: github/gh-aw-actions/setup-cli@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
         with:


### PR DESCRIPTION
## Summary

Applies the two supply-chain hardening changes suggested in #10 (originally drafted by Repo Assist, which couldn't push workflow-file changes itself):

1. **Pin `actions/checkout@v6` → `@de0fac2e # v6.0.2`** in `copilot-setup-steps.yml`. Every other workflow in the repo pins to an immutable SHA; this was the one holdout. Same SHA as used across `agentics-maintenance.yml` and all the compiled lock files.
2. **Add `.github/dependabot.yml`** — weekly Monday sweep for GitHub Actions updates, labeled `dependencies`.

Closes #10.

## Test plan

- [ ] `gh aw validate` passes on main after merge (structural change only; no agent logic touched)
- [ ] First Dependabot run (next Monday) arrives without errors
- [ ] Next `copilot-setup-steps.yml` invocation still checks out correctly